### PR TITLE
Thumbnail generation and test fixes

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -15,7 +15,7 @@ class MainTest(TestCase):
 
     def test_main_until_quit(self):
         """Run through vimiv main once."""
-        v_main.main(True)
+        v_main.main([], True)
 
 
 if __name__ == '__main__':

--- a/vimiv/helpers.py
+++ b/vimiv/helpers.py
@@ -3,7 +3,6 @@
 """Wrappers around standard library functions used in vimiv."""
 
 import os
-from subprocess import Popen, PIPE
 from gi import require_version
 require_version('Gtk', '3.0')
 from gi.repository import Gtk
@@ -20,17 +19,17 @@ scrolltypes["K"] = (Gtk.ScrollType.START, False)
 scrolltypes["L"] = (Gtk.ScrollType.END, True)
 
 # A list of all external commands
-external_commands = []
-try:
-    p = Popen('echo $PATH | tr \':\' \'\n\' | xargs -n 1 ls -1',
-              stdout=PIPE, stderr=PIPE, shell=True)
-    out, err = p.communicate()
-    out = out.decode('utf-8').split()
-    for cmd in sorted(list(set(out))):
-        external_commands.append("!" + cmd)
-except:
-    external_commands = []
-external_commands = tuple(external_commands)
+pathenv = os.environ.get('PATH')
+if pathenv is not None:
+    executables = set()
+    for bindir in pathenv.split(':'):
+        try:
+            executables |= set(["!" + exe for exe in os.listdir(bindir)])
+        except OSError:
+            continue
+    external_commands = tuple(sorted(list(executables)))
+else:
+    external_commands = ()
 
 
 def listdir_wrapper(path, show_hidden=False):

--- a/vimiv/imageactions.py
+++ b/vimiv/imageactions.py
@@ -157,8 +157,8 @@ class Thumbnails:
             # Correct name
             thumb_ext = ".thumbnail_%dx%d" % (self.thumbsize[0],
                                               self.thumbsize[1])
-            outfile_ext = infile.split(".")[0] + thumb_ext + ".png"
-            outfile_base = os.path.basename(outfile_ext)
+            infile_base = os.path.basename(infile)
+            outfile_base = infile_base.split(".")[0] + thumb_ext + ".png"
             outfile = os.path.join(self.directory, outfile_base)
             # Only if they aren't cached already
             if outfile_base not in self.thumbnails:

--- a/vimiv/main.py
+++ b/vimiv/main.py
@@ -27,7 +27,7 @@ from vimiv.mark import Mark
 from vimiv.information import Information
 
 
-def main(running_tests=False):
+def main(arguments, running_tests=False):
     """Starting point for vimiv.
 
     Args:
@@ -36,7 +36,7 @@ def main(running_tests=False):
     parser = get_args()
     parse_dirs()
     settings = parse_config()
-    settings = parse_args(parser, settings)
+    settings = parse_args(parser, settings, arguments)
 
     args = settings["GENERAL"]["paths"]
 

--- a/vimiv/parser.py
+++ b/vimiv/parser.py
@@ -56,7 +56,7 @@ def get_args():
     return parser
 
 
-def parse_args(parser, settings, arguments=None):
+def parse_args(parser, settings, arguments):
     """Parse the arguments and return the modified settings.
 
     Args:
@@ -66,10 +66,7 @@ def parse_args(parser, settings, arguments=None):
 
     Return: Modified settings after parsing the arguments.
     """
-    if arguments:
-        args = parser.parse_args(arguments)
-    else:
-        args = parser.parse_args()
+    args = parser.parse_args(arguments)
     if args.show_version:
         information = Information()
         print(information.get_version())

--- a/vimiv/vimiv
+++ b/vimiv/vimiv
@@ -5,4 +5,4 @@ import sys
 import vimiv
 
 if __name__ == '__main__':
-    sys.exit(vimiv.main.main())
+    sys.exit(vimiv.main.main(sys.argv))


### PR DESCRIPTION
I've stumbled over a few issues while packaging vimiv for [NixOS](https://nixos.org/):

  * Thumbnail generation doesn't work properly if leading directories of input files contain a dot.
  * Finding executables in `$PATH` relies on external tools.
  * `main_test` picks up `nosetests` arguments.

This branch should fix these issues.